### PR TITLE
Add explicit TensorRT engine destroy logic to avoid memory leak

### DIFF
--- a/python/trt_sam2/__init__.py
+++ b/python/trt_sam2/__init__.py
@@ -43,9 +43,12 @@ class SAM2Image:
             decoder_batch_limit
         )
         if not self.instance:
-            raise RuntimeError("Failed to create SAM2Image instance")
-
+            raise RuntimeError("Failed to create SAM2Image instance")        
+        
         # Define argument and return types for the shared library functions
+        self.lib.destroy_sam2image.argtypes = [ctypes.c_void_p]
+        self.lib.destroy_sam2image.restype = None
+        
         self.lib.sam2image_set_image.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_ubyte), ctypes.c_int, ctypes.c_int]
         self.lib.sam2image_set_image.restype = None
 
@@ -66,6 +69,9 @@ class SAM2Image:
         ]
         self.lib.sam2image_get_max_entropy.restype = None
 
+    def destroy(self) :
+        self.lib.destroy_sam2image(self.instance)
+        
     def set_image(self, image: np.ndarray):
         """Set the input image for processing."""
         if image.dtype != np.uint8:

--- a/src/sam2_ctypes.cpp
+++ b/src/sam2_ctypes.cpp
@@ -39,6 +39,15 @@ extern "C"
             encoder_path, decoder_path, encoder_input_size, precision, decoder_batch_limit));
         return static_cast<void*>(sam2);
     }
+
+    // Destroy SAM2Image
+    void destroy_sam2image(void* instance)
+    {
+       if (instance) {
+	 delete static_cast<std::shared_ptr<SAM2Image>*>(instance);
+       }
+    }
+  
     // Set image in SAM2Image
     void sam2image_set_image(void* instance, const unsigned char* image_data, int width, int height)
     {


### PR DESCRIPTION
This PR adds explicit engine destruction logic for python API to avoid potential GPU memory leaks when using TensorRT.

This helps ensure memory is released properly in long-running inference pipelines or when multiple engines are loaded sequentially.